### PR TITLE
Add Babel's object rest and spread plugin to "compile" to ES5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-react": "^7.0.0",
+    "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
     "@wordpress/eslint-plugin": "^1.0.1",
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,9 @@ const babelLoader = {
   loader: 'babel-loader',
   options: {
     presets: ['@babel/preset-react'],
+    plugins: [
+      '@babel/plugin-proposal-object-rest-spread',
+    ],
   },
 };
 


### PR DESCRIPTION
Or else IE and Edge browsers will complain about it, i.e. break the whole editor 😉